### PR TITLE
docs: update README to display example as javascript

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For examples of how to use the SDK, check out our [onyx-ssi-sdk-examples repo](h
 
 Below code shows the Issuance, Claiming, and Verification of W3C Credential/Presentation.
 
-```shell
+```javascript
 
 //DID Key
 const didKey = new KeyDIDMethod()


### PR DESCRIPTION
# What :computer: 
* Update `README` to display example as JavaScript

# Why :hand:
* This makes the code in the example easier to read and comments are more easily separated

# Evidence :camera:
**BEFORE:**
![image](https://github.com/jpmorganchase/onyx-ssi-sdk/assets/1890113/f71abe41-1d59-49a0-ae2c-a6974efcf955)

**AFTER:**
![image](https://github.com/jpmorganchase/onyx-ssi-sdk/assets/1890113/e2a6c35b-7ed9-49c0-9e77-694331d4143e)
